### PR TITLE
Add files key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "repository": "madou/yubaba",
   "author": "Michael Dougall",
   "license": "MIT",
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "tdd": "jest --watch",
     "build": "lerna run build",


### PR DESCRIPTION
This will prevent publishing unnecessary files. [see package.json docs](https://docs.npmjs.com/files/package.json#files)

In particular, it looks like `src` is published twice. Once in the root, and again in the `dist/` directory. [source](https://cdn.jsdelivr.net/npm/yubaba/)

This will make sure that npm publish only picks up the `dist/` folder.