### PR TITLE
Dynamic duration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,7 @@
     "react/prefer-stateless-function": "never",
     "react/sort-comp": "off",
     "react/destructuring-assignment": "never",
+    "import/prefer-default-export": "off",
     "import/no-extraneous-dependencies": [
       "error",
       { "devDependencies": ["**/*test.tsx", "**/*stories.tsx"] }

--- a/packages/yubaba/package.json
+++ b/packages/yubaba/package.json
@@ -13,7 +13,7 @@
   },
   "size-limit": [
     {
-      "limit": "5.4 KB",
+      "limit": "5.7 KB",
       "path": "dist/es6/packages/yubaba/src/index.js"
     }
   ],

--- a/packages/yubaba/src/animations/Reveal/index.tsx
+++ b/packages/yubaba/src/animations/Reveal/index.tsx
@@ -7,12 +7,14 @@ import Collector, {
 } from '../../Collector';
 import { standard } from '../../lib/curves';
 import { combine } from '../../lib/style';
+import { dynamic } from '../../lib/duration';
+import { Duration } from '../types';
 
 export interface RevealProps extends CollectorChildrenProps {
   /**
    * How long the animation should take over {duration}ms.
    */
-  duration: number;
+  duration: Duration;
 
   /**
    * zIndex to be applied to the moving element.
@@ -49,7 +51,7 @@ export interface RevealProps extends CollectorChildrenProps {
  */
 export default class Reveal extends React.Component<RevealProps> {
   static defaultProps = {
-    duration: 500,
+    duration: 'dynamic',
     timingFunction: standard(),
     childrenTransformX: true,
     childrenTransformY: true,
@@ -111,6 +113,10 @@ targetElement was missing.`);
 
   animate: AnimationCallback = (data, onFinish, setChildProps) => {
     const { timingFunction, duration, useClipPath } = this.props;
+    const calculatedDuration =
+      duration === 'dynamic'
+        ? dynamic(data.origin.elementBoundingBox, data.destination.elementBoundingBox)
+        : duration;
 
     const revealStyles = useClipPath
       ? {
@@ -126,19 +132,19 @@ targetElement was missing.`);
         ...prevStyles,
         ...revealStyles,
         transition: combine(
-          `height ${duration}ms ${timingFunction}, width ${duration}ms ${timingFunction}, clip-path ${duration}ms ${timingFunction}`
+          `height ${calculatedDuration}ms ${timingFunction}, width ${calculatedDuration}ms ${timingFunction}, clip-path ${calculatedDuration}ms ${timingFunction}`
         )(prevStyles.transition),
       }),
       className: () =>
         css({
           '> *': {
             transform: `translate3d(0, 0, 0)`,
-            transition: `transform ${duration}ms ${timingFunction}`,
+            transition: `transform ${calculatedDuration}ms ${timingFunction}`,
           },
         }),
     });
 
-    setTimeout(() => onFinish(), duration);
+    setTimeout(() => onFinish(), calculatedDuration);
   };
 
   render() {

--- a/packages/yubaba/src/animations/types.tsx
+++ b/packages/yubaba/src/animations/types.tsx
@@ -1,0 +1,1 @@
+export type Duration = number | 'dynamic';

--- a/packages/yubaba/src/lib/dom.tsx
+++ b/packages/yubaba/src/lib/dom.tsx
@@ -86,6 +86,16 @@ export function calculateElementCenterInViewport(elementBoundingBox: ElementBoun
 /**
  * @hidden
  */
+export function getWindowDimensions() {
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+}
+
+/**
+ * @hidden
+ */
 export function calculateWindowCentre() {
   return {
     left: Math.ceil(window.innerWidth / 2),

--- a/packages/yubaba/src/lib/duration/index.tsx
+++ b/packages/yubaba/src/lib/duration/index.tsx
@@ -1,0 +1,65 @@
+import { ElementBoundingBox, getWindowDimensions } from '../dom';
+import { calculateHypotenuse, clamp } from '../math';
+
+/**
+ * Element [0] is the expanding time.
+ * Element [1] is the collapsing time.
+ */
+const distanceTiming = {
+  medium: [250, 200],
+  large: [300, 250],
+};
+
+const MEDIUM_TRAVEL_PERCENT = 39;
+
+/**
+ * @hidden
+ */
+export function getScreenSizeWeight(width: number) {
+  const weightedWidth = Number((width / 900).toFixed(2));
+  return clamp(weightedWidth, 1, 1.5);
+}
+
+/**
+ * Will return a number bounded around how far the element had to travel which will
+ * always be a whole number.
+ *
+ * According to google via https://material.io/design/motion/speed.html#duration:
+ * - Small (travelled 0-5% of the screen) = 100ms
+ * - Medium (travelled 6-39% of the screen) = 250ms expand, 200ms collapse
+ * - Large (travelled 40%+ of the screen) = 300ms expand, 250ms collapse
+ *
+ * If the origin is smaller than the destination, it will use expand time.
+ * Else it will use collapse time.
+ *
+ * @param origin ElementBoundingBox
+ * @param destination ElementBoundingBox
+ */
+export function dynamic(origin: ElementBoundingBox, destination: ElementBoundingBox): number {
+  const screenDimensions = getWindowDimensions();
+  const screenHypotenuse = calculateHypotenuse(screenDimensions);
+  const distanceBetweenElements = calculateHypotenuse({
+    width: origin.location.left - destination.location.left,
+    height: origin.location.top - destination.location.top,
+  });
+  const sizeDifference = calculateHypotenuse(destination.size) - calculateHypotenuse(origin.size);
+  const percentOfScreenTravelled = Math.ceil(
+    ((sizeDifference + distanceBetweenElements) / screenHypotenuse) * 100
+  );
+  // If size difference is greater than zero then we are expanding.
+  // If expanding we dip into the first element of timing. Else the second.
+  const timingIndex = sizeDifference >= 0 ? 0 : 1;
+  // We use the screen size to determine the weight, which in turn is used
+  // in the final calculation of the duration.
+  const screenWeight = getScreenSizeWeight(screenDimensions.width);
+
+  let duration;
+
+  if (percentOfScreenTravelled <= MEDIUM_TRAVEL_PERCENT) {
+    duration = distanceTiming.medium[timingIndex];
+  } else {
+    duration = distanceTiming.large[timingIndex];
+  }
+
+  return Math.ceil(duration * screenWeight);
+}

--- a/packages/yubaba/src/lib/duration/test.tsx
+++ b/packages/yubaba/src/lib/duration/test.tsx
@@ -1,0 +1,129 @@
+import { dynamic, getScreenSizeWeight } from './index';
+import { ElementBoundingBox, getWindowDimensions } from '../dom';
+
+jest.mock('../dom');
+
+describe('duration util', () => {
+  const setViewportDimensions = (width: number, height: number) => {
+    (getWindowDimensions as jest.Mock).mockReturnValue({ width, height });
+  };
+
+  const createBoundingBox = (box: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  }): ElementBoundingBox => ({
+    location: {
+      left: box.left,
+      top: box.top,
+    },
+    size: {
+      width: box.width,
+      height: box.height,
+    },
+    raw: {} as any,
+  });
+
+  describe('dynamic duration', () => {
+    beforeEach(() => {
+      setViewportDimensions(500, 1000);
+    });
+
+    it('should return medium duration when moving 10 to 49 percent of the screen', () => {
+      const origin = createBoundingBox({
+        height: 50,
+        width: 50,
+        top: 0,
+        left: 0,
+      });
+      const destination = createBoundingBox({
+        height: 50,
+        width: 50,
+        top: 400,
+        left: 0,
+      });
+
+      const duration = dynamic(origin, destination);
+
+      expect(duration).toEqual(250);
+    });
+
+    it('should return medium duration when expading 10 to 49 percent of the screen', () => {
+      const origin = createBoundingBox({
+        height: 50,
+        width: 500,
+        top: 0,
+        left: 0,
+      });
+      const destination = createBoundingBox({
+        height: 300,
+        width: 500,
+        top: 0,
+        left: 0,
+      });
+
+      const duration = dynamic(origin, destination);
+
+      expect(duration).toEqual(250);
+    });
+
+    it('should return large duration when moving over 50 percent of the screen', () => {
+      const origin = createBoundingBox({
+        height: 50,
+        width: 50,
+        top: 0,
+        left: 0,
+      });
+      const destination = createBoundingBox({
+        height: 50,
+        width: 50,
+        top: 600,
+        left: 0,
+      });
+
+      const duration = dynamic(origin, destination);
+
+      expect(duration).toEqual(300);
+    });
+
+    it('should return large duration when expanding over 50 percent of the screen', () => {
+      const origin = createBoundingBox({
+        height: 50,
+        width: 50,
+        top: 0,
+        left: 0,
+      });
+      const destination = createBoundingBox({
+        height: 1000,
+        width: 500,
+        top: 0,
+        left: 0,
+      });
+
+      const duration = dynamic(origin, destination);
+
+      expect(duration).toEqual(300);
+    });
+  });
+
+  describe('viewport weight', () => {
+    it('should return small weight', () => {
+      const weight = getScreenSizeWeight(500);
+
+      expect(weight).toEqual(1);
+    });
+
+    it('should return weight for medium', () => {
+      const weight = getScreenSizeWeight(1100);
+
+      expect(weight).toEqual(1.22);
+    });
+
+    it('should return weight for large', () => {
+      const weight = getScreenSizeWeight(1440);
+
+      expect(weight).toEqual(1.5);
+    });
+  });
+});

--- a/packages/yubaba/src/lib/math.tsx
+++ b/packages/yubaba/src/lib/math.tsx
@@ -23,3 +23,11 @@ export function calculateHypotenuse({ width, height }: Dimensions) {
 export function percentageDifference(from: number, to: number) {
   return from / to;
 }
+
+/**
+ * @hidden
+ */
+export function clamp(num: number, min: number, max: number) {
+  // eslint-disable-next-line no-nested-ternary
+  return num <= min ? min : num >= max ? max : num;
+}


### PR DESCRIPTION
Adds dynamic duration as default duration for all animations.

Basic overview of dynamic duration is that it will calculate how far the element had to travel across the viewport, and come back with a duration.

Inspired by https://material.io/design/motion/speed.html#duration