### PR TITLE
remove need for name prop with self targetted animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ yarn add yubaba react@^16.4.x react-dom@^16.4.x emotion@^10.x.x
 import Animator, { Move } from 'yubaba';
 
 ({ isLarge }) => (
-  <Animator name="my-first-baba" triggerSelfKey={isLarge}>
+  <Animator triggerSelfKey={isLarge}>
     <Move>{anim => <div {...anim} className={isLarge ? 'large' : 'small'} />}</Move>
   </Animator>
 );

--- a/packages/yubaba/src/Animator/__docs__/docs.mdx
+++ b/packages/yubaba/src/Animator/__docs__/docs.mdx
@@ -53,7 +53,7 @@ Using the `triggerSelfKey` prop to force an animation on itself over a state cha
 import Animator, { Move } from 'yubaba';
 
 ({ children, itemId }) => (
-  <Animator triggerSelfKey={itemId} name="self-target">
+  <Animator triggerSelfKey={itemId}>
     <Move>{children}</Move>
   </Animator>
 );

--- a/packages/yubaba/src/Animator/test.tsx
+++ b/packages/yubaba/src/Animator/test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount, ReactWrapper } from 'enzyme'; // eslint-disable-line import/no-extraneous-dependencies
+import { mount, ReactWrapper, shallow } from 'enzyme'; // eslint-disable-line import/no-extraneous-dependencies
 import { MemoryRouter, Link } from 'react-router-dom';
 import { WrappedAnimator as Animator } from '../Animator';
 import Target from '../FocalTarget';
@@ -33,7 +33,41 @@ const startAnimation = (wrapper: ReactWrapper) => {
 };
 
 describe('<Animator />', () => {
+  it('should warn if name isnt defined', () => {
+    console.warn = jest.fn();
+    process.env.NODE_ENV = 'development';
+
+    mount(<Animator>{props => <div {...props} />}</Animator>);
+
+    expect(console.warn).toHaveBeenCalledWith(`yubaba v0.0.0
+
+"name" prop needs to be defined. Without it you may have problems matching up animator targets. You will not get this error when using "triggerSelfKey" prop.`);
+  });
+
+  it('should not warn if not using name when doing self targetted animator', () => {
+    console.warn = jest.fn();
+    process.env.NODE_ENV = 'development';
+
+    shallow(<Animator triggerSelfKey="hi">{props => <div {...props} />}</Animator>);
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('should not warn when using name', () => {
+    console.warn = jest.fn();
+    process.env.NODE_ENV = 'development';
+
+    shallow(
+      <Animator name="hello" triggerSelfKey="hi">
+        {props => <div {...props} />}
+      </Animator>
+    );
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
   it('should callback when animation has finished', done => {
+    (getElementBoundingBox as jest.Mock).mockReturnValue(utils.domData());
     const Animation = utils.createTestAnimation();
     const wrapper = mount(
       <utils.AnimatorUnderTest

--- a/packages/yubaba/src/Animator/types.tsx
+++ b/packages/yubaba/src/Animator/types.tsx
@@ -1,0 +1,66 @@
+import { CollectorChildrenProps, InlineStyles } from '../Collector';
+import { InjectedProps } from '../VisibilityManager';
+
+export type AnimationFunc = () => Promise<void>;
+
+export interface MappedAnimation {
+  animate: AnimationFunc;
+  beforeAnimate: AnimationFunc;
+  afterAnimate: AnimationFunc;
+  cleanup: () => void;
+}
+
+export type AnimationBlock = MappedAnimation[];
+
+export interface ChildProps {
+  style?: InlineStyles;
+  className?: string;
+}
+
+export interface AnimatorState {
+  childProps: ChildProps;
+  animationsMarkup: React.ReactPortal[];
+}
+
+export interface BaseAnimatorProps extends CollectorChildrenProps, InjectedProps {
+  /**
+   * Callback called when all animations have finished and been cleaned up. Fired from the triggering Animator
+   * component.
+   */
+  onFinish: () => void;
+
+  /**
+   * Time this component will wait until it throws away the animation.
+   * Defaults to 50ms, might want to bump it up if loading something that was code split.
+   */
+  timeToWaitForNextAnimator: number;
+
+  /**
+   * HTMLElement container used when creating elements for animations,
+   * generally only supporting animations will need this.
+   */
+  container: HTMLElement | (() => HTMLElement);
+}
+
+export interface AnimatorProps extends BaseAnimatorProps {
+  /**
+   * Name of the animator, this should match the target animator.
+   */
+  name: string;
+
+  /**
+   * Use if your element is expected to persist through an animation.
+   * When you transition to the next state set your "in" to false and vice versa.
+   * This lets the Animator components know when to execute the animations.
+   *
+   * You can't use this with the "triggerSelfKey".
+   */
+  in?: boolean;
+
+  /**
+   * Will trigger animations over itself when this prop changes.
+   *
+   * You can't use the with the "in" prop.
+   */
+  triggerSelfKey?: string;
+}

--- a/packages/yubaba/src/VisibilityManager/test.tsx
+++ b/packages/yubaba/src/VisibilityManager/test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { mount } from 'enzyme'; // eslint-disable-line
 import { WrappedAnimator as Animator } from '../Animator';
 import { WrappedVisibilityManager as VisibilityManager } from '../VisibilityManager';
 import * as utils from '../__tests__/utils';
@@ -51,7 +51,7 @@ describe('<VisibilityManager />', () => {
           <VisibilityManager isInitiallyVisible>
             {props => (
               <span {...props}>
-                <Animator name="aaa" triggerSelfKey={`${shown}`}>
+                <Animator triggerSelfKey={`${shown}`}>
                   <Animation>{({ ref, style }) => <div ref={ref} style={style} />}</Animation>
                 </Animator>
               </span>
@@ -79,7 +79,7 @@ describe('<VisibilityManager />', () => {
           <VisibilityManager isInitiallyVisible>
             {props => (
               <span {...props}>
-                <Animator name="aaa" key={`${shown}`}>
+                <Animator triggerSelfKey={`${shown}`}>
                   <Animation>{({ ref, style }) => <div ref={ref} style={style} />}</Animation>
                 </Animator>
               </span>

--- a/packages/yubaba/src/__docs__/1-introduction/docs.mdx
+++ b/packages/yubaba/src/__docs__/1-introduction/docs.mdx
@@ -51,7 +51,7 @@ yarn add yubaba react@^16.4.x react-dom@^16.4.x emotion@^10.x.x
 import Animator, { Move } from 'yubaba';
 
 ({ isLarge }) => (
-  <Animator name="my-first-baba" triggerSelfKey={isLarge}>
+  <Animator triggerSelfKey={isLarge}>
     <Move>{anim => <div {...anim} className={isLarge ? 'large' : 'small'} />}</Move>
   </Animator>
 );

--- a/packages/yubaba/src/__docs__/2-getting-started/docs.mdx
+++ b/packages/yubaba/src/__docs__/2-getting-started/docs.mdx
@@ -113,7 +113,6 @@ here is their message notification pill made using [ReshapingContainer](/reshapi
         <VisibilityManager isInitiallyVisible>
           {visibility => (
             <ReshapingContainer
-              id="messenger-pill"
               triggerKey={toggler.shown}
               display="inline-block"
               boxShadow="rgba(32, 33, 36, 0.25) 0px 3px 6px"
@@ -148,13 +147,14 @@ here is their message notification pill made using [ReshapingContainer](/reshapi
 
 Sometimes we want to animate over the same element after a state change,
 for example expanding a thumbnail to a large image.
-To do that we can abuse how `key`'s work in react - we just update the key at the same time as the state change.
+To do that we can use the `triggerSelfKey` prop available in the `Animator` component -
+we just update the key at the same time as the state change.
 
 <Playground>
   <Styled.Container>
     <Toggler>
       {({ shown, toggle }) => (
-        <Animator name="same-move" triggerSelfKey={shown}>
+        <Animator triggerSelfKey={shown}>
           <Move>
             {({ ref, style }) => (
               <>

--- a/packages/yubaba/src/__docs__/3-advanced-usage/docs.mdx
+++ b/packages/yubaba/src/__docs__/3-advanced-usage/docs.mdx
@@ -59,9 +59,7 @@ for example here in our _tripe.com_ menu we use it for just that!
 ({ isMenuShown, shownMenuId }) => (
   <CSSTransition in={isMenuShown} unmountOnExit mountOnEnter timeout={{ enter: 0, exit: 100 }}>
     <div class="menu-container">
-      <ReshapingContainer id="reshape-with-transition" triggerKey={shownMenuId}>
-        hello world
-      </ReshapingContainer>
+      <ReshapingContainer triggerKey={shownMenuId}>hello world</ReshapingContainer>
     </div>
   </CSSTransition>
 );
@@ -81,7 +79,7 @@ Here we use Popmotion to do the animating.
 <Playground>
   <Common.Toggler interval>
     {toggler => (
-      <Animator name="popmotion-right" triggerSelfKey={toggler.shown}>
+      <Animator triggerSelfKey={toggler.shown}>
         <PopmotionMoveRight>{anim => <Styled.Root {...anim} />}</PopmotionMoveRight>
       </Animator>
     )}

--- a/packages/yubaba/src/__docs__/4-custom-animations/docs.mdx
+++ b/packages/yubaba/src/__docs__/4-custom-animations/docs.mdx
@@ -161,7 +161,7 @@ export default class OneFullRotation extends Component {
 <Styled.Container>
   <Toggler interval>
     {toggler => (
-      <Animator triggerSelfKey={toggler.shown} name="element-animation-1">
+      <Animator triggerSelfKey={toggler.shown}>
         <OneFullRotation>
           {({ ref, ...props }) => (
             <Styled.InlineBlock
@@ -207,7 +207,7 @@ beforeAnimate = (elements, onFinish, setChildProps) => {
 <Styled.Container>
   <Toggler interval>
     {toggler => (
-      <Animator triggerSelfKey={toggler.shown} name="element-animation-2">
+      <Animator triggerSelfKey={toggler.shown}>
         <Move>
           <OneFullRotation>
             {({ ref, ...props }) => (
@@ -336,7 +336,7 @@ export default class SupportingAnimation extends React.Component {
 <Styled.Container>
   <Toggler>
     {toggler => (
-      <Animator triggerSelfKey={toggler.shown} name="supporting-animation-1">
+      <Animator triggerSelfKey={toggler.shown}>
         <SupportingAnimation>
           {({ ref, ...props }) => (
             <Styled.InlineBlock

--- a/packages/yubaba/src/__docs__/5-troubleshooting/docs.mdx
+++ b/packages/yubaba/src/__docs__/5-troubleshooting/docs.mdx
@@ -9,7 +9,8 @@ order: 1
 ## Animations aren't starting
 
 Sometimes a [Animator](/animator) element is reused by React if the markup where the [Animator](/animator) element was rendered didn't change.
-To get around this you can use [React `key` prop](https://reactjs.org/docs/lists-and-keys.html#keys) to force each [Animator](/animator) to re-mount.
+If you're rendering two different trees get around this by using [React `key` prop](https://reactjs.org/docs/lists-and-keys.html#keys) to force each [Animator](/animator) to re-mount.
+Else think about using the `triggerSelfKey` prop for self targetting.
 
 ## TypeError: Cannot read property 'getBoundingClientRect' of undefined
 

--- a/packages/yubaba/src/animations/ReshapingContainer/__docz__/TripeHoverMenu.tsx
+++ b/packages/yubaba/src/animations/ReshapingContainer/__docz__/TripeHoverMenu.tsx
@@ -70,7 +70,6 @@ const TripeHoverMenu = () => (
             >
               <ReshapingContainer
                 triggerKey={toggler.shown.shown}
-                id="reshaping-example"
                 boxShadow="0 50px 100px -20px rgba(50,50,93,.25), 0 30px 60px -30px rgba(0,0,0,.3), 0 -18px 60px -10px rgba(0,0,0,.025)"
                 background="#fff"
                 maxWidth="500px"

--- a/packages/yubaba/src/animations/ReshapingContainer/__docz__/docs.mdx
+++ b/packages/yubaba/src/animations/ReshapingContainer/__docz__/docs.mdx
@@ -30,7 +30,6 @@ import { ReshapingContainer } from 'yubaba';
 ({ children }) => (
   <ReshapingContainer
     triggerKey={children}
-    id="reshaping-example"
     boxShadow="0 50px 100px -20px rgba(50,50,93,.25), 0 30px 60px -30px rgba(0,0,0,.3), 0 -18px 60px -10px rgba(0,0,0,.025)"
     background="#fff"
     maxWidth="500px"

--- a/packages/yubaba/src/animations/ReshapingContainer/index.tsx
+++ b/packages/yubaba/src/animations/ReshapingContainer/index.tsx
@@ -6,11 +6,6 @@ import { Duration } from '../types';
 
 export interface ReshapingContainerProps {
   /**
-   * This should be a unique identifier across your whole app.
-   */
-  id: string;
-
-  /**
    * Will trigger the animation when this key changes.
    * Change this when you want the animations to trigger,
    * ideally when the children JSX has changed.
@@ -126,7 +121,6 @@ export default class ReshapingContainer extends React.PureComponent<ReshapingCon
       margin,
       padding,
       duration,
-      id,
       display,
       timingFunction,
       borderRadius,
@@ -136,7 +130,7 @@ export default class ReshapingContainer extends React.PureComponent<ReshapingCon
     const ComponentAs = rest.as as any;
 
     return (
-      <Animator name={`${id}-container`} triggerSelfKey={triggerKey}>
+      <Animator triggerSelfKey={triggerKey}>
         <Move duration={duration} timingFunction={timingFunction}>
           {anim => (
             <ComponentAs

--- a/packages/yubaba/src/animations/ReshapingContainer/stories.tsx
+++ b/packages/yubaba/src/animations/ReshapingContainer/stories.tsx
@@ -24,7 +24,6 @@ storiesOf('yubaba/ReshapingContainer', module)
       <Toggler>
         {toggler => (
           <ReshapingContainer
-            id="dialog-move"
             triggerKey={`${toggler.shown}`}
             boxShadow="0 1px 50px rgba(32, 33, 36, 0.1)"
             padding="16px"
@@ -61,7 +60,6 @@ storiesOf('yubaba/ReshapingContainer', module)
       <Toggler>
         {toggler => (
           <ReshapingContainer
-            id="dialog-width"
             triggerKey={`${toggler.shown}`}
             boxShadow="0 1px 50px rgba(32, 33, 36, 0.1)"
             padding="16px"

--- a/packages/yubaba/src/animations/Reveal/stories.tsx
+++ b/packages/yubaba/src/animations/Reveal/stories.tsx
@@ -19,7 +19,7 @@ storiesOf('yubaba/Reveal', module).add('ChildrenHeightChanging', () => (
   <Container>
     <Toggler>
       {toggler => (
-        <Animator name="reveal" triggerSelfKey={`${toggler.shown}`}>
+        <Animator triggerSelfKey={`${toggler.shown}`}>
           <Reveal>
             {anim => (
               <div {...anim}>

--- a/packages/yubaba/src/animations/RevealReshapingContainer/index.tsx
+++ b/packages/yubaba/src/animations/RevealReshapingContainer/index.tsx
@@ -63,12 +63,12 @@ export default class RevealReshapingContainer extends React.PureComponent<
   }
 
   render() {
-    const { children, duration, id, timingFunction, triggerKey } = this.props;
+    const { children, duration, timingFunction, triggerKey } = this.props;
 
     return (
       <ReshapingContainer {...this.props}>
         {reshaping => (
-          <Animator name={`${id}-children`} triggerSelfKey={triggerKey}>
+          <Animator triggerSelfKey={triggerKey}>
             <Reveal
               duration={duration}
               offset={this.getInversePaddingParts()}

--- a/packages/yubaba/src/animations/Swipe/__docs__/docs.mdx
+++ b/packages/yubaba/src/animations/Swipe/__docs__/docs.mdx
@@ -24,7 +24,7 @@ import { Swipe } from 'yubaba';
   <Common.Toggler>
     {({ shown, toggle }) => (
       <Styled.Container onClick={() => toggle()} interactive>
-        <Animator name="swipe" triggerSelfKey={shown}>
+        <Animator triggerSelfKey={shown}>
           <Swipe background="#ff5e6d" direction={shown ? 'left' : 'right'}>
             {({ ref, style }) => <div style={style} ref={ref} />}
           </Swipe>


### PR DESCRIPTION
Really great change for the api - can remove name prop now when doing self targeted animations!

```diff
() =>
  <Animator
-    name="change-size"
    triggerSelfKey={size}
  />
```